### PR TITLE
feat: disable detect object injection

### DIFF
--- a/index.js
+++ b/index.js
@@ -217,6 +217,7 @@ module.exports = {
     'unicorn/prefer-ternary': ['error', 'only-single-line'], // Compresses things down to more readable ternary (only if both are single lines)
     'unicorn/require-number-to-fixed-digits-argument': 'error', // Is more explicit than assuming the default
     'unicorn/throw-new-error': 'error', // Is a sensible convention that should be followed
+    'security/detect-object-injection': 'off', // This rule goes off all the time and is almost always wrong.
   },
   overrides: [
     {


### PR DESCRIPTION
This rule sucks and I hate it. It misses 99.9% of the time. It is just a warn, but bleh.