### PR TITLE
feat: allow async functions without await

### DIFF
--- a/index.js
+++ b/index.js
@@ -224,6 +224,7 @@ module.exports = {
     'unicorn/require-number-to-fixed-digits-argument': 'error', // Is more explicit than assuming the default
     'unicorn/throw-new-error': 'error', // Is a sensible convention that should be followed
     'security/detect-object-injection': 'off', // This rule goes off all the time and is almost always wrong.
+    '@typescript-eslint/require-await': 'off', // Sometimes a function needs a promise to fit an interface. Or sometimes you want to throw instead of reject. No one really makes a function async without meaning to. especially combined with the forced return type declaration
   },
   overrides: [
     {

--- a/test/example.ts
+++ b/test/example.ts
@@ -1,1 +1,4 @@
 const a = {};
+async function test(): Promise<never> {
+  throw new Error('wow');
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,9 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "module": "commonjs"
+    "module": "commonjs",
+    "lib": ["ES2015"]
   },
-  "include": [
-    "test/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["test/*.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
typescript encourages consistant interfaces, and sometimes you wanna return a promise even if your function is synchronous.
Or sometimes you wanna `throw new Error('')` and not have to think about if this is breaking the promise interface.

so this will allow the following:
```typescript
async function wow(): Promise<never> {
  throw new Error('wow');
}
```

or 

```typescript
async function golly(): Promise<CoolInterface> {
  return { "gee whiz": "🤓" };
}
```