### PR TITLE
fix: disable lodash rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,15 @@ function getTypescriptVersion() {
   return null;
 }
 module.exports = {
-  plugins: ['@typescript-eslint', 'promise', 'eslint-comments', 'unicorn', 'sonarjs', 'security-node', 'prettier'],
+  plugins: [
+    '@typescript-eslint',
+    'promise',
+    'eslint-comments',
+    'unicorn',
+    'sonarjs',
+    'security-node',
+    'prettier',
+  ],
   parserOptions: {
     project: './tsconfig.json', // this is only really for local testing. the extending projects will override this
   },

--- a/index.js
+++ b/index.js
@@ -11,16 +11,7 @@ function getTypescriptVersion() {
   return null;
 }
 module.exports = {
-  plugins: [
-    '@typescript-eslint',
-    'promise',
-    'eslint-comments',
-    'unicorn',
-    'sonarjs',
-    'security-node',
-    'you-dont-need-lodash-underscore',
-    'prettier',
-  ],
+  plugins: ['@typescript-eslint', 'promise', 'eslint-comments', 'unicorn', 'sonarjs', 'security-node', 'prettier'],
   parserOptions: {
     project: './tsconfig.json', // this is only really for local testing. the extending projects will override this
   },
@@ -29,7 +20,6 @@ module.exports = {
     'airbnb-typescript/base', //add some typescript variations to the airbnb base style
     'plugin:@typescript-eslint/recommended', // add some of the basic typescript rules
     'plugin:@typescript-eslint/recommended-requiring-type-checking', // add some cooler typescipt rules
-    'plugin:you-dont-need-lodash-underscore/compatible-warn', // if there is an exact one-to-one native function available over lodash, then warn
     'plugin:promise/recommended', // use promises as well as possible
     'plugin:eslint-comments/recommended', // these are meta rules about eslint configing itself. don't be silly, basically
     'plugin:sonarjs/recommended', // security audit rules that might help us see very damaging bugs

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "eslint-plugin-security-node": "^1.1.0",
         "eslint-plugin-sonarjs": "^0.11.0",
         "eslint-plugin-unicorn": "^40.0.0",
-        "eslint-plugin-you-dont-need-lodash-underscore": "^6.12.0",
         "prettier": "2.5.1",
         "semver": "7.3.2"
       },
@@ -4086,17 +4085,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
-    "node_modules/eslint-plugin-you-dont-need-lodash-underscore": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-you-dont-need-lodash-underscore/-/eslint-plugin-you-dont-need-lodash-underscore-6.12.0.tgz",
-      "integrity": "sha512-WF4mNp+k2532iswT6iUd1BX6qjd3AV4cFy/09VC82GY9SsRtvkxhUIx7JNGSe0/bLyd57oTr4inPFiIaENXhGw==",
-      "dependencies": {
-        "kebab-case": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/eslint-rule-documentation": {
       "version": "1.0.23",
       "resolved": "https://registry.npmjs.org/eslint-rule-documentation/-/eslint-rule-documentation-1.0.23.tgz",
@@ -5583,11 +5571,6 @@
       "engines": {
         "node": ">=4.0"
       }
-    },
-    "node_modules/kebab-case": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/kebab-case/-/kebab-case-1.0.1.tgz",
-      "integrity": "sha512-txPHx6nVLhv8PHGXIlAk0nYoh894SpAqGPXNvbg2hh8spvHXIah3+vT87DLoa59nKgC6scD3u3xAuRIgiMqbfQ=="
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -10833,14 +10816,6 @@
         }
       }
     },
-    "eslint-plugin-you-dont-need-lodash-underscore": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-you-dont-need-lodash-underscore/-/eslint-plugin-you-dont-need-lodash-underscore-6.12.0.tgz",
-      "integrity": "sha512-WF4mNp+k2532iswT6iUd1BX6qjd3AV4cFy/09VC82GY9SsRtvkxhUIx7JNGSe0/bLyd57oTr4inPFiIaENXhGw==",
-      "requires": {
-        "kebab-case": "^1.0.0"
-      }
-    },
     "eslint-rule-documentation": {
       "version": "1.0.23",
       "resolved": "https://registry.npmjs.org/eslint-rule-documentation/-/eslint-rule-documentation-1.0.23.tgz",
@@ -11842,11 +11817,6 @@
         "array-includes": "^3.1.3",
         "object.assign": "^4.1.2"
       }
-    },
-    "kebab-case": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/kebab-case/-/kebab-case-1.0.1.tgz",
-      "integrity": "sha512-txPHx6nVLhv8PHGXIlAk0nYoh894SpAqGPXNvbg2hh8spvHXIah3+vT87DLoa59nKgC6scD3u3xAuRIgiMqbfQ=="
     },
     "kind-of": {
       "version": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "eslint-plugin-security-node": "^1.1.0",
     "eslint-plugin-sonarjs": "^0.11.0",
     "eslint-plugin-unicorn": "^40.0.0",
-    "eslint-plugin-you-dont-need-lodash-underscore": "^6.12.0",
     "prettier": "2.5.1",
     "semver": "7.3.2"
   },


### PR DESCRIPTION
BREAKING CHANGE: Disable any "you dont need lodash" rules. We can usually trust the dev to not abuse it.