### PR TITLE
chore: cleanup eslint config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ You can configure ESLint to use the Intolerable Style Guide by adding the follow
 import { ISG } from 'eslint-config-intolerable-style-guide';
 
 default export [
+  {
+    ignores: ['eslint.config.mjs'],
+  },
+
   ...ISG,
 
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,7 +1,11 @@
-const { ISG } = require('./dist');
+import { ISG } from './dist/index.js';
 
 // This file is used for internal testing only.
-module.exports = [
+export default [
+  {
+    ignores: ['eslint.config.mjs'],
+  },
+
   ...ISG,
 
   {

--- a/example-project/eslint.config.mjs
+++ b/example-project/eslint.config.mjs
@@ -1,7 +1,11 @@
-const { ISG } = require('eslint-config-intolerable-style-guide');
+import { ISG } from 'eslint-config-intolerable-style-guide';
 
 // This file is used for internal testing only.
-module.exports = [
+export default [
+  {
+    ignores: ['eslint.config.mjs'],
+  },
+
   ...ISG,
 
   {

--- a/example-project/package.json
+++ b/example-project/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint -c ./eslint.config.js ./src/good-file.ts"
+    "lint": "eslint -c ./eslint.config.mjs ./src/good-file.ts"
   },
   "dependencies": {
     "eslint-config-intolerable-style-guide": ".."


### PR DESCRIPTION
A minor change to move to a move consistant usable of eslint.config.mjs, and instruct it to ignore linting on itself as it is not a TypeScript file.