### PR TITLE
fix(rules): relax @typescript-eslint/naming-convention naming convention

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,9 @@
   "typescript.tsdk": "node_modules\\typescript\\lib",
   "conventionalCommits.scopes": [
     "rules"
+  ],
+  "eslint.workingDirectories": [
+    ".",
+    "./example-project"
   ]
 }

--- a/example-project/src/good-file.ts
+++ b/example-project/src/good-file.ts
@@ -1,3 +1,20 @@
 import { join } from 'path';
 
+function goodFunction(): void {
+  console.log('This is a good function');
+}
+
+function CapitalLetterFunction(): void {
+  console.log('This is sadly required because there are a few times you need to do this.');
+  console.log('Code review will need to be the method of making sure lower case letters are used for function names.');
+}
+
 console.log(join('a', 'b'));
+goodFunction();
+CapitalLetterFunction();
+
+export class Blarg {
+  smallFunc(): void {
+    console.log('This is a small function');
+  }
+}

--- a/src/rules/typescript-eslint.ts
+++ b/src/rules/typescript-eslint.ts
@@ -59,6 +59,10 @@ export default tseslint.config({
         trailingUnderscore: 'allow',
       },
       {
+        selector: 'function',
+        format: ['camelCase', 'PascalCase'],
+      },
+      {
         selector: 'typeLike',
         format: ['PascalCase'],
       },


### PR DESCRIPTION
This is unfortunately a necessary evil, as there are enough legitimate corner cases (eg. decorators, or functions that return a class definition) that it is annoying to eslint-ignore them. Manual code review will be required for function names.